### PR TITLE
Replaced Initialise with OnPostActivate(Mod mod)

### DIFF
--- a/CYOC2/Main.cs
+++ b/CYOC2/Main.cs
@@ -20,15 +20,11 @@ namespace CYOC2
         public static bool IsActivated;
 
         public Main() : base("toyemaker.plateup.cyoc2", "Choose Your Own Cards", "Toyemaker", "2.0.0", ">=1.1.0 <=1.5.0", Assembly.GetExecutingAssembly()) { }
-        protected override void Initialise()
+        protected override void OnPostActivate(Mod mod)
         {
             IsActivated = false;
-
             SetupMenus();
-
             Debug.Log("[Choose Your Own Cards]: v2.0 loaded.");
-
-            base.Initialise();
         }
 
         protected override void OnUpdate()


### PR DESCRIPTION
Replaced Initialise with OnPostActivate(Mod mod), this is because Initialise is called on World injection, which happens when you load singleplayer, and multiplayer, causing it to be called twice, thus duplicating any menus registered with it.